### PR TITLE
Integrate ChatGPT API support

### DIFF
--- a/Sources/OpenAI/Internal/Models/Networking/ChatModel.swift
+++ b/Sources/OpenAI/Internal/Models/Networking/ChatModel.swift
@@ -1,0 +1,37 @@
+//
+//  ChatModel.swift
+//  
+//
+//  Created by Cole Roberts on 3/3/23.
+//
+
+import Foundation
+
+// MARK: - `ChatModel` -
+
+public struct ChatModel: Decodable {
+    let id: String
+    let object: String
+    let created: Int
+    let choices: [Choice]
+    let usage: UsageModel
+}
+
+// MARK: - `ChatModel+Choice` -
+
+public extension ChatModel {
+    struct Choice: Decodable {
+        let index: Int
+        let message: Message
+        let finishReason: String
+    }
+}
+
+// MARK: - `ChatModel+Choice.Message` -
+
+public extension ChatModel.Choice {
+    struct Message: Decodable {
+        let role: String
+        let content: String
+    }
+}

--- a/Sources/OpenAI/Internal/Models/Networking/CompletionModel.swift
+++ b/Sources/OpenAI/Internal/Models/Networking/CompletionModel.swift
@@ -10,10 +10,11 @@ import Foundation
 // MARK: - `CompletionModel` -
 
 public struct CompletionModel: Decodable {
-    public let id: String
-    public let object: String
-    public let created: Int
-    public let choices: [Choice]
+    let id: String
+    let object: String
+    let created: Int
+    let choices: [Choice]
+    let usage: UsageModel
 }
 
 // MARK: - `CompletionModel+Choice`

--- a/Sources/OpenAI/Internal/Models/Networking/ImagesModel.swift
+++ b/Sources/OpenAI/Internal/Models/Networking/ImagesModel.swift
@@ -1,5 +1,5 @@
 //
-//  DataResponseModel.swift
+//  ImagesModel.swift
 //  
 //
 //  Created by Cole Roberts on 12/6/22.
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - `DataResponseModel` -
 
-public struct DataResponseModel<T: Decodable>: Decodable {
+public struct ImagesModel: Decodable {
     public let created: Int
-    public let data: T
+    public let data: [ImageModel]
 }

--- a/Sources/OpenAI/Internal/Models/Networking/UsageModel.swift
+++ b/Sources/OpenAI/Internal/Models/Networking/UsageModel.swift
@@ -1,0 +1,16 @@
+//
+//  UsageModel.swift
+//  
+//
+//  Created by Cole Roberts on 3/3/23.
+//
+
+import Foundation
+
+// MARK: - `UsageModel` -
+
+struct UsageModel: Decodable {
+    let promptTokens: Int
+    let completionTokens: Int
+    let totalTokens: Int
+}

--- a/Sources/OpenAI/Internal/Models/OpenAI+ChatRequest+Requestable.swift
+++ b/Sources/OpenAI/Internal/Models/OpenAI+ChatRequest+Requestable.swift
@@ -1,0 +1,60 @@
+//
+//  OpenAI+ChatRequest+Requestable.swift
+//  
+//
+//  Created by Cole Roberts on 3/3/23.
+//
+
+import Foundation
+
+// MARK: - `OpenAI.ChatRequest+Requestable` -
+
+extension OpenAI.ChatRequest: Requestable {
+    typealias ResponseModel = ChatModel
+    static var path: String { "/chat/completions"}
+    static var method: APIRequestMethod { .post }
+    
+    private enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case temperature
+        case topP
+        case n
+        case stream
+        case stop
+        case maxTokens
+        case presencePenalty
+        case frequencyPenalty
+        case user
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(model.stringRepresentation, forKey: .model)
+        try container.encode(messages, forKey: .messages)
+        try container.encodeIfPresent(temperature, forKey: .temperature)
+        try container.encodeIfPresent(topP, forKey: .topP)
+        try container.encodeIfPresent(n, forKey: .n)
+        try container.encodeIfPresent(stream, forKey: .stream)
+        try container.encodeIfPresent(stop, forKey: .stop)
+        try container.encodeIfPresent(maxTokens, forKey: .maxTokens)
+        try container.encodeIfPresent(presencePenalty, forKey: .presencePenalty)
+        try container.encodeIfPresent(frequencyPenalty, forKey: .frequencyPenalty)
+        try container.encodeIfPresent(user, forKey: .user)
+    }
+}
+
+// MARK: - `OpenAI.ChatRequest+Message+Encodable` -
+
+extension OpenAI.ChatRequest.Message: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case role
+        case content
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(role.rawValue, forKey: .role)
+        try container.encode(content, forKey: .content)
+    }
+}

--- a/Sources/OpenAI/Internal/Models/OpenAI+ImageRequest+Requestable.swift
+++ b/Sources/OpenAI/Internal/Models/OpenAI+ImageRequest+Requestable.swift
@@ -10,7 +10,7 @@ import Foundation
 // MARK: - `OpenAI.ImageRequest+Requestable` -
 
 extension OpenAI.ImageRequest: Requestable {
-    typealias ResponseModel = DataResponseModel<[ImageModel]>
+    typealias ResponseModel = ImagesModel
     static var path: String { "/images/generations" }
     static var method: APIRequestMethod { .post }
     

--- a/Sources/OpenAI/Public/Requests/OpenAI+ChatRequest.swift
+++ b/Sources/OpenAI/Public/Requests/OpenAI+ChatRequest.swift
@@ -1,0 +1,159 @@
+//
+//  OpenAI+ChatRequest.swift
+//  
+//
+//  Created by Cole Roberts on 3/2/23.
+//
+
+import Foundation
+
+// MARK: - `OpenAI+ChatRequest` -
+
+public extension OpenAI {
+    struct ChatRequest {
+        /// ID of the model to use. See `Model`
+        let model: OpenAI.ChatRequest.Model
+        
+        /// The messages to generate chat completions for, in the chat format.
+        let messages: [Message]
+        
+        /// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the
+        /// output more random, while lower values like 0.2 will make it more focused and deterministic
+        /// We generally recommend altering this or `top_p` but not both.
+        let temperature: Double?
+        
+        /// An alternative to sampling with temperature, called nucleus sampling, where the model
+        /// considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens
+        /// comprising the top 10% probability mass are considered.
+        /// We generally recommend altering this or temperature but not both.
+        let topP: Double?
+        
+        /// How many chat completion choices to generate for each input message.
+        let n: Int?
+        
+        /// If set, partial message deltas will be sent, like in ChatGPT. Tokens will be sent as data-only
+        /// server-sent events as they become available, with the stream terminated by a data:
+        /// [DONE] message.
+        let stream: Bool?
+        
+        /// Up to 4 sequences where the API will stop generating further tokens.
+        let stop: String?
+        
+        /// The maximum number of tokens allowed for the generated answer. By default, the number
+        /// of tokens the model can return will be (4096 - prompt tokens).
+        let maxTokens: Int?
+        
+        /// Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they
+        /// appear in the text so far, increasing the model's likelihood to talk about new topics.
+        let presencePenalty: Double?
+        
+        /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing
+        /// frequency in the text so far, decreasing the model's likelihood to repeat the same line
+        /// verbatim.
+        let frequencyPenalty: Double?
+
+        /// A unique identifier representing your end-user, which can help OpenAI to monitor and
+        /// detect abuse.
+        let user: String?
+        
+        public init(
+            model: OpenAI.ChatRequest.Model,
+            messages: [Message],
+            temperature: Double? = nil,
+            topP: Double? = nil,
+            n: Int? = nil,
+            stream: Bool? = nil,
+            stop: String? = nil,
+            maxTokens: Int? = nil,
+            presencePenalty: Double? = nil,
+            frequencyPenalty: Double? = nil,
+            user: String? = nil
+        ) {
+            self.model = model
+            self.messages = messages
+            self.temperature = temperature
+            self.topP = topP
+            self.n = n
+            self.stream = stream
+            self.stop = stop
+            self.maxTokens = maxTokens
+            self.presencePenalty = presencePenalty
+            self.frequencyPenalty = frequencyPenalty
+            self.user = user
+        }
+    }
+}
+
+// MARK: - `OpenAI.ChatRequest+Model` -
+
+public extension OpenAI.ChatRequest {
+    /// See: https://beta.openai.com/docs/models/overview
+    enum Model {
+        /// See `GPT3`
+        case gpt3(GPT3)
+        
+        public enum GPT3: String {
+            /// Most capable GPT-3.5 model and optimized for chat at 1/10th the cost of text-davinci-003.
+            /// Will be updated with our latest model iteration.
+            case turbo
+            
+            /// Snapshot of gpt-3.5-turbo from March 1st 2023. Unlike gpt-3.5-turbo,
+            /// this model will not receive updates, and will only be supported for a
+            /// three month period ending on June 1st 2023.
+            case turbo0301
+        }
+        
+        // MARK: - `Utility` -
+        
+        var stringRepresentation: String {
+            switch self {
+            case .gpt3(let type):
+                switch `type` {
+                case .turbo:
+                    return "gpt-3.5-turbo"
+                case .turbo0301:
+                    return "gpt-3.5-turbo-0301"
+                }
+            }
+        }
+    }
+}
+
+// MARK: - `OpenAI.ChatRequest+Message` -
+
+public extension OpenAI.ChatRequest {
+    struct Message {
+        let role: Role
+        let content: String
+        
+        // MARK: - `Utility` -
+        
+        static func assistant(content: String) -> Self {
+            .init(role: .assistant, content: content)
+        }
+        
+        static func system(content: String) -> Self {
+            .init(role: .system, content: content)
+        }
+        
+        static func user(content: String) -> Self {
+            .init(role: .user, content: content)
+        }
+    }
+}
+
+// MARK: - `OpenAI.ChatRequest.Message+Role` -
+
+public extension OpenAI.ChatRequest.Message {
+    enum Role: String {
+        case assistant
+        case system
+        case user
+        
+        // MARK: - `Utility` -
+        
+        var stringRepresentation: String {
+            rawValue
+        }
+    }
+}

--- a/Sources/OpenAI/Public/Requests/OpenAI+CompletionRequest.swift
+++ b/Sources/OpenAI/Public/Requests/OpenAI+CompletionRequest.swift
@@ -109,12 +109,11 @@ public extension OpenAI {
     }
 }
 
-// MARK: - `OpenAI+CompletionRequest+Model` -
+// MARK: - `OpenAI.CompletionRequest+Model` -
 
 public extension OpenAI.CompletionRequest {
-    /// See: https://beta.openai.com/docs/models/overviewaa
+    /// See: https://beta.openai.com/docs/models/overview
     enum Model {
-        
         /// See `GPT3`
         case gpt3(GPT3)
         

--- a/Sources/OpenAI/Public/Requests/OpenAI+ImageRequest.swift
+++ b/Sources/OpenAI/Public/Requests/OpenAI+ImageRequest.swift
@@ -17,7 +17,7 @@ public extension OpenAI {
         /// The number of images to generate. Must be between 1 and 10.
         let numberOfImages: Int?
         
-        // The size of the generated images. (small: 256x256, normal: 512x512, large: 1024x1024x)
+        /// The size of the generated images. (small: 256x256, normal: 512x512, large: 1024x1024x)
         let size: Size?
         
         /// The format in which the generated images are returned.

--- a/Tests/OpenAITests/Mock/MockOpenAI.swift
+++ b/Tests/OpenAITests/Mock/MockOpenAI.swift
@@ -14,12 +14,53 @@ final class MockOpenAI: OpenAISDK {
         return self
     }
     
-    func images(for request: OpenAI.ImageRequest) async throws -> DataResponseModel<[ImageModel]> {
-        return DataResponse(created: 0, data: [Image(url: "https://google.com")])
+    func chats(for model: OpenAI.ChatRequest) async throws -> ChatModel {
+        ChatModel(
+            id: "",
+            object: "",
+            created: 0,
+            choices: [
+                .init(
+                    index: 0,
+                    message: .init(
+                        role: "assistant",
+                        content: "The 2020 World Series was played in Globe Life Field located in Arlington, Texas, USA."),
+                    finishReason: "stop"
+                )
+            ],
+            usage: .mock()
+        )
     }
     
-    func completions(for request: OpenAI.CompletionRequest) async throws -> CompletionModel {
-        let completion = CompletionModel(id: "", object: "", created: 0, choices: [])
-        return completion
+    func completions(for model: OpenAI.CompletionRequest) async throws -> CompletionModel {
+        CompletionModel(
+            id: "",
+            object: "",
+            created: 0,
+            choices: [
+                .init(
+                    text: "This was a test",
+                    index: 0
+                )
+            ],
+            usage: .mock()
+        )
+    }
+    
+    func images(for model: OpenAI.ImageRequest) async throws -> ImagesModel {
+        ImagesModel(
+            created: 0,
+            data: [
+                .init(url: "https://google.com")
+            ]
+        )
+    }
+}
+
+// MARK: - `MockOpenAI+FakeUsage` -
+
+extension UsageModel {
+    static func mock() -> Self {
+        .init(promptTokens: 0, completionTokens: 0, totalTokens: 0)
     }
 }

--- a/Tests/OpenAITests/MockOpenAITests.swift
+++ b/Tests/OpenAITests/MockOpenAITests.swift
@@ -13,23 +13,50 @@ final class MockOpenAITests: XCTestCase {
         self.openai = MockOpenAI()
     }
     
-    // MARK: - Images
+    // MARK: - Chats
     
-    func test_makeImageRequest() async {
+    func test_chatRequest() async {
         do {
-            let images = try await openai.images(for: .init(prompt: "A mock request"))
-            assert(!images.data.isEmpty)
+            let chats = try await openai.chats(
+                for: .init(
+                    model: .gpt3(.turbo),
+                    messages: [
+                        .system(content: "You are a helpful assistant."),
+                        .user(content: "Who won the world series in 2020?"),
+                        .assistant(content: "The Los Angeles Dodgers won the World Series in 2020."),
+                        .user(content: "Where was it played?")
+                    ]
+                )
+            )
+            assert(!chats.choices.isEmpty)
         } catch {
             fatalError(error.localizedDescription)
         }
     }
-
-    // MARK: - Completions (Complex)
     
-    func test_makeComplexCompletionRequest() async {
+    // MARK: - Completions
+    
+    func test_completionRequest() async {
         do {
-            let completions = try await openai.completions(for: .init(model: .gpt3(.davinci), prompt: "Say this is a test"))
-            assert(completions.created == 0)
+            let completions = try await openai.completions(
+                for: .init(
+                    model: .gpt3(.davinci),
+                    prompt: "Say this is a test")
+            )
+            assert(!completions.choices.isEmpty)
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }
+    
+    // MARK: - Images
+    
+    func test_imageRequest() async {
+        do {
+            let images = try await openai.images(
+                for: .init(prompt: "A white siamese cat")
+            )
+            assert(!images.data.isEmpty)
         } catch {
             fatalError(error.localizedDescription)
         }


### PR DESCRIPTION
# Overview 
Integrates support for the newly introduced [ChatGPT API](https://openai.com/blog/introducing-chatgpt-and-whisper-apis).

### Misc
- This also includes general housekeeping and other minor improvements.


